### PR TITLE
add 'create table' support

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,14 +19,14 @@ Jedlik.prototype.query = function() {
   json.KeyConditions[this._data.hashkey.key] = {
     AttributeValueList: [{}]
   };
-  
+
   json.KeyConditions[this._data.hashkey.key].AttributeValueList[0][this._data.hashkey.type] = this._data.hashkey.value.toString();
-  
+
   json.KeyConditions[this._data.rangekey.key] = {
     AttributeValueList: [{}],
     ComparisonOperator: this._data.rangekey.comparisonOp
   };
-  
+
   json.KeyConditions[this._data.rangekey.key].AttributeValueList[0][this._data.rangekey.type] = this._data.rangekey.value.toString();
 
   this.addIfExists('TableName', 'tablename', json);
@@ -42,7 +42,7 @@ Jedlik.prototype.update = function() {
   var json = {
     AttributeUpdates: {},
     Key: {
-    }    
+    }
   };
 
   Object.keys(this._data.attributesToUpdate).forEach(function(key) {
@@ -50,17 +50,17 @@ Jedlik.prototype.update = function() {
 
     json.AttributeUpdates[key] = {
       Action: attributeToUpdate.action,
-      Value: {} 
+      Value: {}
     };
     json.AttributeUpdates[key].Value[attributeToUpdate.type] = attributeToUpdate.value;
   }.bind(this));
 
   json.Key[this._data.hashkey.key] = {};
   json.Key[this._data.hashkey.key][this._data.hashkey.type] = this._data.hashkey.value;
-  
+
   json.Key[this._data.rangekey.key] = {};
   json.Key[this._data.rangekey.key][this._data.rangekey.type] = this._data.rangekey.value;
-  
+
   this.addIfExists('TableName', 'tablename', json);
 
   return json;
@@ -75,20 +75,20 @@ var getType = function(value) {
   return Number.isFinite(value) ? 'N' : 'S';
 };
 
-Jedlik.prototype.hashkey = function(key, value) {
+Jedlik.prototype.hashkey = function(key, value, type) {
   this._data.hashkey = {
     key: key,
     value: value,
-    type: getType(value)
+    type: type || getType(value)
   }
   return this;
 };
 
-Jedlik.prototype.rangekey = function(key, value, comparisonOp) {
+Jedlik.prototype.rangekey = function(key, value, comparisonOp, type) {
   this._data.rangekey = {
     key: key,
     value: value,
-    type: getType(value),
+    type: type || getType(value),
     comparisonOp: comparisonOp || 'EQ'
   }
   return this;
@@ -104,6 +104,11 @@ Jedlik.prototype.attributes = function(attributes) {
   return this;
 };
 
+Jedlik.prototype.throughput = function (throughput) {
+  this._data.throughput = throughput;
+  return this;
+};
+
 Jedlik.prototype.updateAttribute = function(key, value, action) {
   this._data.attributesToUpdate[key] = {
     value: value.toString(),
@@ -115,16 +120,59 @@ Jedlik.prototype.updateAttribute = function(key, value, action) {
 
 Jedlik.prototype.del = function() {
   var json = {
-    Key: {}    
+    Key: {}
   };
 
   json.Key[this._data.hashkey.key] = {};
   json.Key[this._data.hashkey.key][this._data.hashkey.type] = this._data.hashkey.value;
-  
+
   json.Key[this._data.rangekey.key] = {};
   json.Key[this._data.rangekey.key][this._data.rangekey.type] = this._data.rangekey.value;
-  
+
   this.addIfExists('TableName', 'tablename', json);
+
+  return json;
+};
+
+Jedlik.prototype.createTable = function () {
+  var throughput = {
+    read: (this._data.throughput && this._data.throughput.read) || 1,
+    write: (this._data.throughput && this._data.throughput.write) || 1
+  };
+
+  var json = {
+    AttributeDefinitions: [],
+    KeySchema: [],
+    ProvisionedThroughput: {
+      ReadCapacityUnits: throughput.read,
+      WriteCapacityUnits: throughput.write
+    },
+    TableName: this._data.tablename
+  };
+
+  if(this._data.hashkey) {
+    json.AttributeDefinitions.push({
+      AttributeName: this._data.hashkey.key,
+      AttributeType: this._data.hashkey.type
+    });
+    json.KeySchema.push({
+      AttributeName: this._data.hashkey.key,
+      KeyType: 'HASH'
+    });
+  } else {
+    throw new Error('Setup hash key using "hashkey" method to create a new table');
+  }
+
+  if(this._data.rangekey) {
+    json.AttributeDefinitions.push({
+      AttributeName: this._data.rangekey.key,
+      AttributeType: this._data.rangekey.type
+    });
+    json.KeySchema.push({
+      AttributeName: this._data.rangekey.key,
+      KeyType: 'RANGE'
+    });
+  }
 
   return json;
 };

--- a/test/fixtures/createTable_hash.json
+++ b/test/fixtures/createTable_hash.json
@@ -1,0 +1,11 @@
+{
+  "AttributeDefinitions": [
+    { "AttributeName": "hashkey", "AttributeType": "S" }
+  ],
+  "KeySchema": [
+    { "AttributeName": "hashkey", "KeyType": "HASH" }
+  ],
+  "ProvisionedThroughput": { "ReadCapacityUnits": 1, "WriteCapacityUnits": 1 },
+  "TableName": "tablename"
+}
+

--- a/test/fixtures/createTable_range.json
+++ b/test/fixtures/createTable_range.json
@@ -1,0 +1,12 @@
+{
+  "AttributeDefinitions": [
+    { "AttributeName": "hashkey", "AttributeType": "S" },
+    { "AttributeName": "rangekey", "AttributeType": "N" }
+  ],
+  "KeySchema": [
+    { "AttributeName": "hashkey", "KeyType": "HASH" },
+    { "AttributeName": "rangekey", "KeyType": "RANGE" }
+  ],
+  "ProvisionedThroughput": { "ReadCapacityUnits": 1, "WriteCapacityUnits": 1 },
+  "TableName": "tablename"
+}

--- a/test/fixtures/createTable_throughput.json
+++ b/test/fixtures/createTable_throughput.json
@@ -1,0 +1,10 @@
+{
+  "AttributeDefinitions": [
+    { "AttributeName": "hashkey", "AttributeType": "S" }
+  ],
+  "KeySchema": [
+    { "AttributeName": "hashkey", "KeyType": "HASH" }
+  ],
+  "ProvisionedThroughput": { "ReadCapacityUnits": 5, "WriteCapacityUnits": 7 },
+  "TableName": "tablename"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,15 @@ describe('lib', function() {
       };
       expect(this.jedlik.hashkey(expected.key, expected.value)._data.hashkey).to.deep.equal(expected);
     });
+
+    it('should add hashkey property with the same type as specified in call params', function () {
+      var expected = {
+        key: 'KEY',
+        value: 'VALUE',
+        type: 'N'
+      };
+      expect(this.jedlik.hashkey(expected.key, expected.value, 'N')._data.hashkey).to.deep.equal(expected);
+    });
   });
 
   describe('rangekey', function() {
@@ -43,6 +52,7 @@ describe('lib', function() {
       };
       expect(this.jedlik.rangekey(expected.key, expected.value)._data.rangekey).to.deep.equal(expected);
     });
+
     it('should add rangekey property', function() {
       var expected = {
         key: 'KEY',
@@ -51,6 +61,16 @@ describe('lib', function() {
         comparisonOp: 'COMPARISONOP'
       };
       expect(this.jedlik.rangekey(expected.key, expected.value, expected.comparisonOp)._data.rangekey).to.deep.equal(expected);
+    });
+
+    it('should add rangekey property with the same type as specified in call params', function() {
+      var expected = {
+        key: 'KEY',
+        value: 'VALUE',
+        type: 'B',
+        comparisonOp: 'COMPARISONOP'
+      };
+      expect(this.jedlik.rangekey(expected.key, expected.value, expected.comparisonOp, 'B')._data.rangekey).to.deep.equal(expected);
     });
   });
 
@@ -79,7 +99,7 @@ describe('lib', function() {
           value: '1234',
           type: 'N',
           action: 'PUT'
-        }      
+        }
       };
       expect(this.jedlik
         .updateAttribute('attribute1', 'STR','PUT' )
@@ -125,6 +145,38 @@ describe('lib', function() {
       .updateAttribute('attribute1', 'STR', 'PUT')
       .updateAttribute('attribute2', 1234)
       .update()).to.deep.equal(require('./fixtures/update'));
+  });
+
+  describe('createTable', function () {
+    it('should return a valid json for createTable when only hashkey is used', function () {
+      expect(this.jedlik
+        .tablename('tablename')
+        .hashkey('hashkey', null, 'S')
+        .createTable()).to.deep.equal(require('./fixtures/createTable_hash'));
+    });
+
+    it('should return a valid json for createTable when both hashkey and rangekey are used', function () {
+      expect(this.jedlik
+        .tablename('tablename')
+        .hashkey('hashkey', null, 'S')
+        .rangekey('rangekey', null, null, 'N')
+        .createTable()).to.deep.equal(require('./fixtures/createTable_range'));
+    });
+
+    it('should throw an error if user tries to call create table without calling "hashkey" method first', function () {
+      var tablename = this.jedlik.tablename('tablename')
+      var createTable = tablename.createTable.bind(tablename);
+
+      expect(createTable).to.throw('Setup hash key using "hashkey" method to create a new table');
+    });
+
+    it('should return a valid json for createTable with provision throughput set if it is present', function () {
+      expect(this.jedlik
+        .tablename('tablename')
+        .hashkey('hashkey', null, 'S')
+        .throughput({read: 5, write: 7})
+        .createTable()).to.deep.equal(require('./fixtures/createTable_throughput'));
+    });
   });
 
   it('should return a valid json for delete', function() {


### PR DESCRIPTION
- added support for create table operation

```
jedlik
.tablename('tablename')
.hashkey('hashkey', null, 'S')
.rangekey('rangekey', null, null, 'N')
.throughput({read: 5, write: 7})
.createTable())
```
- added ability to specify hash and range keys types directly without inferring them from the value
- (misc.) removed end-of-line whitespaces 
